### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ password: postgres
 Documentation is accessible at the following URL:
 http://efi.jonathan-xu.com/
 
-Note: Please ensure you access this server with `http` and not `https`. Our documentation server is not configured for https, since acquiring the requisite SSL certificate is out of our budget. Modern browsers automatically redirect to using `https`, so if you have this setting enabled in your browser, you might face issues accessing this page.
-
-
 TODO: update the below shields.
 [![Build Status](https://app.travis-ci.com/melaasar/cs130-template.svg?branch=master)](https://app.travis-ci.com/github/melaasar/cs130-template)
 [![Release](https://img.shields.io/github/v/release/melaasar/cs130-template?label=release)](https://github.com/melaasar/cs130-template/releases/latest)


### PR DESCRIPTION
update url to doc server

i provisioned a subdomain on my own domain so that we can change the destination IP on the fly if something happens (e.g. if the server crashes)

The architecture is the subdomain (efi.jonathan-xu.com) is an A record that points to the IP of the server.
Within the server, I use a reverse proxy by nginx, open to port 80 allowing users to connect. nginx forwards requests to pydoc (on port 8080, internally). we use nginx to allow for SSL certificates

